### PR TITLE
Update main.yml

### DIFF
--- a/roles/prepare/tasks/main.yml
+++ b/roles/prepare/tasks/main.yml
@@ -63,4 +63,4 @@
   copy: src=95-k8s-sysctl.conf dest=/etc/sysctl.d/95-k8s-sysctl.conf
 
 - name: 生效系统参数
-  shell: "sysctl -p /etc/sysctl.d/95-k8s-sysctl.conf"
+  shell: "modprobe br_netfilter; sysctl -p /etc/sysctl.d/95-k8s-sysctl.conf"


### PR DESCRIPTION
修复CentOS 7下生效系统参数部分支持
报错信息：
fatal: [192.168.200.101]: FAILED! => {"changed": true, "cmd": "sysctl -p /etc/sysctl.d/95-k8s-sysctl.conf", "delta": "0:00:00.005074", "end": "2018-03-14 10:19:04.479229", "msg": "non-zero return code", "rc": 255, "start": "2018-03-14 10:19:04.474155", "stderr": "sysctl: cannot stat /proc/sys/net/bridge/bridge-nf-call-iptables: 没有那个文件或目录\nsysctl: cannot stat /proc/sys/net/bridge/bridge-nf-call-ip6tables: 没有那个文件或目录\nsysctl: cannot stat /proc/sys/net/bridge/bridge-nf-call-arptables: 没有那个文件或目录", "stderr_lines": ["sysctl: cannot stat /proc/sys/net/bridge/bridge-nf-call-iptables: 没有那个文件或目录", "sysctl: cannot stat /proc/sys/net/bridge/bridge-nf-call-ip6tables: 没有那个文件或目录", "sysctl: cannot stat /proc/sys/net/bridge/bridge-nf-call-arptables: 没有那个文件或目录"], "stdout": "net.ipv4.ip_forward = 1", "stdout_lines": ["net.ipv4.ip_forward = 1"]}
fatal: [192.168.200.100]: FAILED! => {"changed": true, "cmd": "sysctl -p /etc/sysctl.d/95-k8s-sysctl.conf", "delta": "0:00:00.150119", "end": "2018-03-14 10:19:04.641509", "msg": "non-zero return code", "rc": 255, "start": "2018-03-14 10:19:04.491390", "stderr": "sysctl: cannot stat /proc/sys/net/bridge/bridge-nf-call-iptables: 没有那个文件或目录\nsysctl: cannot stat /proc/sys/net/bridge/bridge-nf-call-ip6tables: 没有那个文件或目录\nsysctl: cannot stat /proc/sys/net/bridge/bridge-nf-call-arptables: 没有那个文件或目录", "stderr_lines": ["sysctl: cannot stat /proc/sys/net/bridge/bridge-nf-call-iptables: 没有那个文件或目录", "sysctl: cannot stat /proc/sys/net/bridge/bridge-nf-call-ip6tables: 没有那个文件或目录", "sysctl: cannot stat /proc/sys/net/bridge/bridge-nf-call-arptables: 没有那个文件或目录"], "stdout": "net.ipv4.ip_forward = 1", "stdout_lines": ["net.ipv4.ip_forward = 1"]}
fatal: [192.168.200.102]: FAILED! => {"changed": true, "cmd": "sysctl -p /etc/sysctl.d/95-k8s-sysctl.conf", "delta": "0:00:00.008421", "end": "2018-03-14 10:19:05.137521", "msg": "non-zero return code", "rc": 255, "start": "2018-03-14 10:19:05.129100", "stderr": "sysctl: cannot stat /proc/sys/net/bridge/bridge-nf-call-iptables: 没有那个文件或目录\nsysctl: cannot stat /proc/sys/net/bridge/bridge-nf-call-ip6tables: 没有那个文件或目录\nsysctl: cannot stat /proc/sys/net/bridge/bridge-nf-call-arptables: 没有那个文件或目录", "stderr_lines": ["sysctl: cannot stat /proc/sys/net/bridge/bridge-nf-call-iptables: 没有那个文件或目录", "sysctl: cannot stat /proc/sys/net/bridge/bridge-nf-call-ip6tables: 没有那个文件或目录", "sysctl: cannot stat /proc/sys/net/bridge/bridge-nf-call-arptables: 没有那个文件或目录"], "stdout": "net.ipv4.ip_forward = 1", "stdout_lines": ["net.ipv4.ip_forward = 1"]}
参考地址：https://www.cnblogs.com/zejin2008/p/7102485.html